### PR TITLE
Avoid usage of .instance

### DIFF
--- a/TRUDUtilsD365/Kernel/AxHelper.cs
+++ b/TRUDUtilsD365/Kernel/AxHelper.cs
@@ -119,7 +119,8 @@ namespace TRUDUtilsD365.Kernel
             {
                 if (_metadataProvider == null)
                 {
-                    _metadataProvider = DesignMetaModelService.Instance.CurrentMetadataProvider;
+                    var designMetaModelService = CoreUtility.GetService<IDesignMetaModelService>() as IDesignMetaModelService;
+                    _metadataProvider = designMetaModelService.CurrentMetadataProvider;
                 }
 
                 return _metadataProvider;
@@ -147,7 +148,8 @@ namespace TRUDUtilsD365.Kernel
             {
                 if (_metaModelService == null)
                 {
-                    _metaModelService = DesignMetaModelService.Instance.CurrentMetaModelService;
+                    var designMetaModelService = CoreUtility.GetService<IDesignMetaModelService>() as IDesignMetaModelService;
+                    _metaModelService = designMetaModelService.CurrentMetaModelService;
                 }
 
                 return _metaModelService;


### PR DESCRIPTION
Would love your input in general about an API or APIs we can provide for easy access to some of these objects and data from the D365 tools.

In general avoid usage of any static Instance properties you're seeing. We'll likely be making some of these obsolete as we evolve our Visual Studio tools.

Thanks for your contributions to the community! We need more of this from other people too :-)